### PR TITLE
update README to point to correct Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple CLI tool that generates a v4 UUID, prints it to the console, and automa
 
 ## 📋 Prerequisites
 
-- Go 1.18+ installed  
+- Go 1.23.4+ installed  
 - A `/usr/local/bin/` directory (or equivalent) in your PATH
 
 ---


### PR DESCRIPTION
Go mod refers to 1.23.4 not 1.18 and while it looks like it should build anyway, maybe forcing people to update is a good idea.